### PR TITLE
Atualizando checagem de reranqueamento e ordenação lafabética

### DIFF
--- a/app/Models/Ranqueamento.php
+++ b/app/Models/Ranqueamento.php
@@ -15,7 +15,8 @@ class Ranqueamento extends Model
 
     public function habs(): HasMany
     {
-        return $this->hasMany(Hab::class);
+        return $this->hasMany(Hab::class)
+            ->orderByRaw('nomhab COLLATE utf8mb4_unicode_ci');
     }
 
     public function declinios(): HasMany

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -45,7 +45,8 @@ class AppServiceProvider extends ServiceProvider
                 if($ultimo_ranqueamento){
                     $score = Score::where('user_id',$user->id)
                                    ->where('ranqueamento_id',$ultimo_ranqueamento->id)
-                                   ->where('posicao',1)
+                                   //->where('posicao',1)
+                                   ->where('prioridade_eleita',1)
                                    ->first();
                     if($score) return false;
                 }


### PR DESCRIPTION
Mudança na checagem para quem está apto ao reranqueamento: 

- impedindo quem passou na prioridade 1 no ranqueamento anterior
- antes estava impedindo os primeiros colocados de cada habilitação somente

Adição do _utf8mb4_unicode_ci_ para que a ordenação das habilitações ficasse correta (problema com a palavra 'árabe')